### PR TITLE
Update extension to Manifest version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Since OpenAI does <a href="https://help.openai.com/en/articles/5722486-how-your-
 
 Introducing leakyGPT, a browser-based DLP extension that looks for any secret exposures (with the help of our <a href="./regexes.json">signatures</a>) within user prompts before they are submitted to chatGPT. The user can decide whether to prevent the prompt from being submitted or continue with it, thus helping prevent secrets from accidentally being trained in the datasets.
 
-## Why Is the Extension Not on Chrome Web Store?
-The extension uses Manifest version 2 which is deprecated and hence Chrome is no longer accepting such submissions to the chrome web store. While the version is deprecated, it should still work fine on the latest versions of Chrome as long as they continue to support it. In the long run, I plan on rewriting the code to make it compatible to Manifest version 3 and then launch it over Chrome Web Store.
-
 ## Does It Log Any Data?
 No data is logged in any step or process of this extension making it completely safe for personal or enterprise use. Which also makes me want to state it here that the extension is completely free of cost and will not have any subscription involved for the time being.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,30 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "leakyGPT",
   "version": "1.0",
   "description": "The one-stop extension to prevent any unintended secret exposures while interacting with chatGPT.",
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://chatgpt.com/*",
     "storage"
   ],
+  "host_permissions": [
+    "*://chatgpt.com/*"
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
-  "web_accessible_resources": ["regexes.json"],
+  "web_accessible_resources": [{
+    "resources": ["regexes.json"],
+    "matches": ["<all_urls>"]
+  }],
+  "action": {
+    "default_icon": {
+      "16": "logo.png",
+      "48": "logo.png",
+      "128": "logo.png"
+    }
+  },
   "icons": {
     "16": "logo.png",
     "48": "logo.png",


### PR DESCRIPTION
Update the project to use Manifest version 3 and make the extension compatible with the Chrome Web Store.

* **manifest.json**
  - Change `manifest_version` to 3
  - Update `background` to use `service_worker` instead of `scripts`
  - Remove `persistent` property from `background`
  - Add `host_permissions` for `*://chatgpt.com/*`
  - Add `action` property with default icon

* **background.js**
  - Replace `chrome.webRequest.onBeforeRequest.addListener` with `chrome.declarativeNetRequest.onBeforeRequest.addListener`
  - Remove `pendingRequest` variable and related logic
  - Update `fetch` call to use `chrome.storage.local.get` for `regexes.json`
  - Remove `chrome.runtime.onStartup.addListener`

* **README.md**
  - Remove section about Manifest version 2 deprecation

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/S4CH/leakyGPT/pull/1?shareId=444637ff-8c99-4a7d-852c-00088a5c988e).